### PR TITLE
Feature/ Add theme support with light and dark modes

### DIFF
--- a/lib/eventak_app.dart
+++ b/lib/eventak_app.dart
@@ -1,29 +1,32 @@
-import 'package:eventak/l10n/app_localizations.dart';
 import 'package:eventak/provider/language_provider.dart';
+import 'package:eventak/provider/theme_provider.dart';
 import 'package:eventak/ui/screens/home/home.dart';
 import 'package:eventak/utils/resources/app_routes.dart';
+import 'package:eventak/utils/resources/app_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
+import 'l10n/app_localizations.dart';
 
 class EventakApp extends StatelessWidget {
   const EventakApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    var languageProvider = Provider.of<LanguageProvider>(context);
+    LanguageProvider languageProvider = Provider.of<LanguageProvider>(context);
+    ThemeProvider themeProvider = Provider.of<ThemeProvider>(context);
 
     return MaterialApp(
       title: 'Eventak',
       debugShowCheckedModeBanner: false,
-
+      initialRoute: AppRoutes.home,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       locale: Locale(languageProvider.currentLanguage),
-
-      initialRoute: AppRoutes.home,
-      routes: {
-        AppRoutes.home: (context) => const Home(),
-      },
+      routes: {AppRoutes.home: (context) => const Home()},
+      theme: AppTheme.lightTheme,
+      darkTheme: AppTheme.darkTheme,
+      themeMode: themeProvider.currentTheme,
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,17 @@
 import 'package:eventak/eventak_app.dart';
 import 'package:eventak/provider/language_provider.dart';
+import 'package:eventak/provider/theme_provider.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
 
 void main() {
-
-  runApp(ChangeNotifierProvider<LanguageProvider>(
-      create: (BuildContext context) => LanguageProvider(),
-      child: EventakApp())
+  runApp(
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (context) => LanguageProvider()),
+        ChangeNotifierProvider(create: (context) => ThemeProvider()),
+      ],
+      child: EventakApp(),
+    ),
   );
 }

--- a/lib/provider/theme_provider.dart
+++ b/lib/provider/theme_provider.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+class ThemeProvider extends ChangeNotifier {
+  ThemeMode currentTheme = ThemeMode.light;
+
+  void toggleTheme({required ThemeMode newThemeMode}) {
+    if (newThemeMode == currentTheme) return;
+    currentTheme = newThemeMode;
+    notifyListeners();
+  }
+}

--- a/lib/ui/screens/home/home.dart
+++ b/lib/ui/screens/home/home.dart
@@ -1,4 +1,5 @@
 import 'package:eventak/provider/language_provider.dart';
+import 'package:eventak/provider/theme_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -15,33 +16,54 @@ class _HomeState extends State<Home> {
   @override
   Widget build(BuildContext context) {
     var languageProvider = Provider.of<LanguageProvider>(context);
+    var themeProvider = Provider.of<ThemeProvider>(context);
     String newLanguage = languageProvider.currentLanguage == 'en' ? 'ar' : 'en';
     return Scaffold(
       appBar: AppBar(title: Text(AppLocalizations.of(context)!.language)),
-      body: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          ElevatedButton(
-            onPressed: () =>
-                languageProvider.changeLanguage(newLanguage: newLanguage),
-            child: Container(
-              width: double.infinity,
-              decoration: BoxDecoration(
-                color: Colors.blueGrey,
-                borderRadius: BorderRadius.circular(10),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 12),
-                child: Center(
-                  child: Text(
-                    AppLocalizations.of(context)!.language,
-                    style: TextStyle(fontSize: 24, color: Colors.white70),
-                  ),
-                ),
-              ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Column(
+          spacing: 24,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            buildButton(
+              title: AppLocalizations.of(context)!.language,
+              onPressed: () {
+                languageProvider.changeLanguage(newLanguage: newLanguage);
+              },
             ),
+
+            buildButton(
+              title: AppLocalizations.of(context)!.theme,
+              onPressed: () {
+                themeProvider.toggleTheme(
+                  newThemeMode: themeProvider.currentTheme == ThemeMode.light
+                      ? ThemeMode.dark
+                      : ThemeMode.light,
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget buildButton({required String title, required Function onPressed}) {
+    return ElevatedButton(
+      onPressed: () => onPressed(),
+      style: ElevatedButton.styleFrom(
+        foregroundColor: Colors.white,
+        backgroundColor: Colors.teal,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        child: Center(
+          child: Text(
+            title,
+            style: TextStyle(fontSize: 24, color: Colors.white70),
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/utils/resources/app_colors.dart
+++ b/lib/utils/resources/app_colors.dart
@@ -1,0 +1,6 @@
+import 'dart:ui';
+
+class AppColors {
+  static const Color bgLight = Color(0xFFF4F7FF);
+  static const Color bgDark = Color(0xFF000F30);
+}

--- a/lib/utils/resources/app_theme.dart
+++ b/lib/utils/resources/app_theme.dart
@@ -1,4 +1,4 @@
-import 'package:evently/utils/resources/app_colors.dart';
+import 'package:eventak/utils/resources/app_colors.dart';
 import 'package:flutter/material.dart';
 
 class AppTheme {

--- a/lib/utils/resources/app_theme.dart
+++ b/lib/utils/resources/app_theme.dart
@@ -1,0 +1,11 @@
+import 'package:evently/utils/resources/app_colors.dart';
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  static final darkTheme = ThemeData(
+    scaffoldBackgroundColor: AppColors.bgDark,
+  );
+  static final lightTheme = ThemeData(
+    scaffoldBackgroundColor: AppColors.bgLight,
+  );
+}


### PR DESCRIPTION
# What I did in this PR:
This PR introduces dynamic theme support, allowing users to switch between light and dark modes seamlessly across the app.

## Changes

* Implement `ThemeProvider` to manage and persist theme state.
* Create centralized `AppTheme` and `AppColors` for consistent light and dark styling.
* Update `EventlyApp` to support dynamic theme switching via `themeMode`.
* Refactor `Home` screen:

  * Add a theme toggle button.
  * Improve UI structure using a reusable button widget.
* Configure `MultiProvider` in `main.dart` to include:

  * `LanguageProvider`
  * `ThemeProvider`

## Preview

https://github.com/user-attachments/assets/929b887a-ac6f-49e6-944b-2107d239e90d
